### PR TITLE
Adds @Validated and JSR-303 to the config props

### DIFF
--- a/graphql-dgs/build.gradle.kts
+++ b/graphql-dgs/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
 
     api("com.graphql-java:graphql-java:${Versions.GRAPHQL_JAVA}")
     api("com.jayway.jsonpath:json-path:2.+")
+    api("org.hibernate.validator:hibernate-validator")
 
     implementation("org.springframework:spring-web")
     implementation("org.springframework:spring-context")
@@ -31,6 +32,8 @@ dependencies {
     implementation("org.springframework.security:spring-security-core")
 
     testImplementation("org.springframework.security:spring-security-core")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+
     testImplementation("io.reactivex.rxjava3:rxjava:3.+")
     testImplementation("io.mockk:mockk:1.10.3-jdk8")
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsGraphQLConfigurationProperties.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsGraphQLConfigurationProperties.kt
@@ -20,6 +20,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.ConstructorBinding
 import org.springframework.boot.context.properties.bind.DefaultValue
 import org.springframework.validation.annotation.Validated
+import javax.validation.Constraint
+import javax.validation.Valid
+import javax.validation.constraints.Pattern
+import kotlin.reflect.KClass
 
 /**
  * Configuration properties for DGS.
@@ -30,16 +34,16 @@ import org.springframework.validation.annotation.Validated
 @Suppress("ConfigurationProperties")
 data class DgsGraphQLConfigurationProperties(
     /** Path to the GraphQL endpoint without trailing slash. */
-    @DefaultValue("/graphql") val path: String,
-    @DefaultValue val graphiql: DgsGraphiQLConfigurationProperties,
-    @DefaultValue val schemaJson: DgsSchemaJsonConfigurationProperties
+    @DefaultValue("/graphql") @field:ValidPath val path: String,
+    @DefaultValue @Valid val graphiql: DgsGraphiQLConfigurationProperties,
+    @DefaultValue @Valid val schemaJson: DgsSchemaJsonConfigurationProperties
 ) {
     /**
      * Configuration properties for GraphiQL.
      */
     data class DgsGraphiQLConfigurationProperties(
         /** Path to the GraphiQL endpoint without trailing slash. */
-        @DefaultValue("/graphiql") val path: String
+        @DefaultValue("/graphiql") @field:ValidPath val path: String
     )
 
     /**
@@ -47,6 +51,19 @@ data class DgsGraphQLConfigurationProperties(
      */
     data class DgsSchemaJsonConfigurationProperties(
         /** Path to the schema-json endpoint without trailing slash. */
-        @DefaultValue("/schema.json") val path: String
+        @DefaultValue("/schema.json") @field:ValidPath val path: String
+    )
+
+    /**
+     * Convenience annotation to prevent having to repeat the @Pattern for every path field.
+     */
+    @kotlin.annotation.Target(AnnotationTarget.FIELD)
+    @kotlin.annotation.Retention(AnnotationRetention.RUNTIME)
+    @Constraint(validatedBy = [])
+    @Pattern(regexp = "^\\/.*[^\\/]\$", message = "path must begin with a slash and not end with a slash")
+    annotation class ValidPath(
+        val message: String = "",
+        val groups: Array<KClass<out Any>> = [],
+        val payload: Array<KClass<out Any>> = []
     )
 }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsGraphQLConfigurationPropertiesValidationTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsGraphQLConfigurationPropertiesValidationTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs
+
+import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Configuration
+
+class DgsGraphQLConfigurationPropertiesValidationTest {
+
+    private val context = ApplicationContextRunner().withConfiguration(
+        AutoConfigurations.of(
+            MockConfigPropsAutoConfiguration::class.java
+        )
+    )!!
+
+    @Test
+    fun graphqlControllerInvalidCustomPathEndsWithSlash() {
+        context
+            .withPropertyValues("dgs.graphql.path: /fooql/")
+            .run { ctx ->
+                assertThat(ctx).hasFailed().failure.getRootCause().hasMessageContaining("path must begin with a slash and not end with a slash")
+            }
+    }
+
+    @Test
+    fun graphqlControllerInvalidCustomPathDoesNotStartWithSlash() {
+        context
+            .withPropertyValues("dgs.graphql.path: fooql")
+            .run { ctx ->
+                assertThat(ctx).hasFailed().failure.getRootCause().hasMessageContaining("path must begin with a slash and not end with a slash")
+            }
+    }
+
+    @Test
+    fun graphqlControllerValidCustomPath() {
+        context
+            .withPropertyValues("dgs.graphql.path: /fooql")
+            .run { ctx ->
+                assertThat(ctx).hasNotFailed()
+            }
+    }
+
+    @Test
+    fun graphiqlControllerInvalidCustomPathEndsWithSlash() {
+        context
+            .withPropertyValues("dgs.graphql.graphiql.path: /fooql/")
+            .run { ctx ->
+                assertThat(ctx).hasFailed().failure.getRootCause().hasMessageContaining("path must begin with a slash and not end with a slash")
+            }
+    }
+
+    @Test
+    fun graphiqlControllerInvalidCustomPathDoesNotStartWithSlash() {
+        context
+            .withPropertyValues("dgs.graphql.graphiql.path: fooql")
+            .run { ctx ->
+                assertThat(ctx).hasFailed().failure.getRootCause().hasMessageContaining("path must begin with a slash and not end with a slash")
+            }
+    }
+
+    @Test
+    fun graphiqlControllerValidCustomPath() {
+        context
+            .withPropertyValues("dgs.graphql.graphiql.path: /fooql")
+            .run { ctx ->
+                assertThat(ctx).hasNotFailed()
+            }
+    }
+
+    @Test
+    fun schemaJsonControllerInvalidCustomPathEndsWithSlash() {
+        context
+            .withPropertyValues("dgs.graphql.schema-json.path: /fooql/")
+            .run { ctx ->
+                assertThat(ctx).hasFailed().failure.getRootCause().hasMessageContaining("path must begin with a slash and not end with a slash")
+            }
+    }
+
+    @Test
+    fun schemaJsonControllerInvalidCustomPathDoesNotStartWithSlash() {
+        context
+            .withPropertyValues("dgs.graphql.schema-json.path: fooql")
+            .run { ctx ->
+                assertThat(ctx).hasFailed().failure.getRootCause().hasMessageContaining("path must begin with a slash and not end with a slash")
+            }
+    }
+
+    @Test
+    fun schemaJsonControllerValidCustomPath() {
+        context
+            .withPropertyValues("dgs.graphql.schema-json.path: /fooql")
+            .run { ctx ->
+                assertThat(ctx).hasNotFailed()
+            }
+    }
+
+    @Test
+    fun defaultsAreValid() {
+        context
+            .run { ctx ->
+                assertThat(ctx).hasNotFailed()
+            }
+    }
+
+    @Configuration
+    @EnableConfigurationProperties(DgsGraphQLConfigurationProperties::class)
+    open class MockConfigPropsAutoConfiguration
+}


### PR DESCRIPTION
This shows what we add to get JSR-303 validations. 

I will run lockdown next to see what the impact of the `hibernate-validator` is. FWIW its in [Spring Boot dependencies](https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies/2.3.6.RELEASE) already. 

